### PR TITLE
Adjustment to handling requests coming from already registered users

### DIFF
--- a/server/app/rooms.py
+++ b/server/app/rooms.py
@@ -57,7 +57,7 @@ class Rooms:
 
     def matchpassword(self, password)->bool:
         """
-            Compare the password equivalency
+            Compare the password equivalency.
         """
         return self._password==password
 
@@ -70,11 +70,20 @@ class Rooms:
             self._password=new_password
             return True 
         return False
-
+    
+    def is_existing_user(self, requestuser: Users)-> bool:
+        """
+            This method checks if the coming request from an existing user or not.
+            This method handles a different scenario compared to the checks in the addclient() method.
+        """
+        for val in self._clients:
+            if val.getname()==requestuser.getname() and val.getipaddr()==requestuser.getipaddr():
+                return True
+        return False
 
     def dropclient(self, peerip:str):
         """
-            Drop a specific user from the room identified by their ip address
+            Drop a specific user from the room identified by their ip address.
         """
         idx=-1
         for i, client  in enumerate(self._clients):

--- a/server/app/signaling_server.py
+++ b/server/app/signaling_server.py
@@ -68,10 +68,14 @@ async def join_room(request):
     newuser=Users(client_name, peerip)
 
     if room_code in rooms.keys():
+        if rooms[room_code].is_existing_user(newuser): ## Check if the user is already a registered user. Useful when an alredy registered user want to retrieve ips of all other connected cliens.
+            if rooms[room_code].getclientnos()<2:
+                return web.Response(body="[Warn]:There are no other user in the room.", status= 425 , content_type="text/plain")
+            return web.Response(body=json.dumps(rooms[room_code].getotherclients(peerip), default=userencoder, indent=2), status=200, content_type='application/json')
+
         match rooms[room_code].addclient(newuser, room_pass):
             case 1:
-                print("Total clients: ", rooms[room_code].getclientnos())
-                if rooms[room_code].getclientnos() <2:
+                if rooms[room_code].getclientnos()<2:
                     return web.Response(body="[Warn]:There are no other user in the room.", status= 425 , content_type="text/plain")
                 return web.Response(body=json.dumps(rooms[room_code].getotherclients(peerip), default=userencoder, indent=2),status=200, content_type='application/json')
             case -1:


### PR DESCRIPTION
Now the signalling server handles requets coming from already registered users by sending back just the ip list of all other clients in the same room if there are atleast 1 other client is in the room.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Clear warning when you join a room with no other participants.
  - Immediate display of other participants when rejoining an existing room.

- Bug Fixes
  - Prevented duplicate entries when rejoining a room where your user already exists, enabling smoother reconnections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->